### PR TITLE
Separate ROG Ally vs Ally X detection, GUI improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,15 +43,18 @@ CHANGELOG.md       # Version history
 - PE Authenticode signing is a pure-Python implementation (DER/PKCS#7/RSA-2048/SHA-256)
 - Input files are never modified — output always written to a separate file
 - **Device auto-detection** from firmware contents via `detect_device()`
-- Device profiles in `DEVICE_PROFILES` dict control per-device behavior
+  - Steam Deck: MEMG at offset 0x80
+  - ROG Ally: PSPG at 0x80, MEMG at 0xC0
+  - ROG Ally X: PSPG at 0x80, MEMG at 0xC8
+- Device profiles in `DEVICE_PROFILES` dict control per-device behavior (`steam_deck`, `rog_ally`, `rog_ally_x`)
 
 ## Device-Specific Notes
 
-| Device | MEMG Offset | Signing | Memory Targets | SPD Types | Notes |
-|--------|-------------|---------|----------------|-----------|-------|
-| Steam Deck | 0x80 | Supported (h2offt) | 16/32GB | LPDDR5 | MEMG directly at offset 0x80 |
-| ROG Ally | 0xC0 | Not supported | 16/32/64GB | LPDDR5 + LPDDR5X | PSPG at 0x80, MEMG at 0xC0 |
-| ROG Ally X | 0xC8 | Not supported | 16/32/64GB | LPDDR5 + LPDDR5X | PSPG at 0x80, MEMG at 0xC8; 24GB stock |
+| Device | Device Key | MEMG Offset | Signing | Stock RAM | Memory Targets | SPD Types | Notes |
+|--------|-----------|-------------|---------|-----------|----------------|-----------|-------|
+| Steam Deck | `steam_deck` | 0x80 | Supported (h2offt) | 16GB | 16/32GB | LPDDR5 | MEMG directly at offset 0x80 |
+| ROG Ally | `rog_ally` | 0xC0 | Not supported | 16GB | 16/32/64GB | LPDDR5 + LPDDR5X | PSPG at 0x80, MEMG at 0xC0 |
+| ROG Ally X | `rog_ally_x` | 0xC8 | Not supported | 24GB | 16/32/64GB | LPDDR5 + LPDDR5X | PSPG at 0x80, MEMG at 0xC8 |
 
 ## Safety Rules
 


### PR DESCRIPTION
## Summary

- **Device detection split**: Distinguish ROG Ally (MEMG at 0xC0) from ROG Ally X (MEMG at 0xC8) using firmware internal structure — no filename dependency, works with SPI dumps
- **GUI: Clear Log button** — clears the log output pane
- **GUI: Copy Log button** — copies all log text to clipboard
- **GUI: 64GB greyed out for Steam Deck** — disabled when SD firmware is loaded since 64GB isn't supported
- **GUI: File dialog defaults to "All files"** — no more manually switching filters for ROG firmware with version-number extensions

## Details

Detection is entirely content-based: the tool checks where the MEMG marker sits relative to the APCB block header. Steam Deck has MEMG at 0x80, ROG Ally has PSPG→MEMG at 0xC0, and ROG Ally X has PSPG→MEMG at 0xC8. This works regardless of filename.

## Test plan

- [x] RC72LA.312 detected as "ROG Ally X"
- [x] RC71LAS.342 detected as "ROG Ally"
- [x] `--device rog_ally_x` CLI override works
- [x] 32GB modify regression passes on Ally X
- [x] GUI module imports cleanly with all 3 device profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)