### PR TITLE
Add SteamOS venv setup instructions for cryptography

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,31 @@ Open your BIOS file, select 32GB, click "Apply Modification". Signing is enabled
 ## Requirements
 
 - **Python 3.8+**
-- **For signing** (optional but recommended): `pip install cryptography`
+- **For signing** (optional, Steam Deck only): `pip install cryptography`
 - Signing is needed for h2offt software flash. Not needed for SPI programmer flash.
+
+### SteamOS Setup (Steam Deck)
+
+SteamOS is Arch-based with a read-only filesystem — avoid `sudo pip install`.
+
+```bash
+# 1. Switch to Desktop Mode and open Konsole (Terminal)
+
+# 2. Create a virtual environment with system site-packages
+python -m venv --system-site-packages ~/sd-apcb-venv
+
+# 3. Activate it
+source ~/sd-apcb-venv/bin/activate
+
+# 4. Upgrade pip and install cryptography
+pip install -U pip
+pip install cryptography
+
+# 5. Run the tool (while venv is active)
+python sd_apcb_tool.py modify <input> <output> --target 32 --sign
+```
+
+You must activate the venv (`source ~/sd-apcb-venv/bin/activate`) each time before running the tool with `--sign`.
 
 ## How It Works
 

--- a/sd_apcb_gui.py
+++ b/sd_apcb_gui.py
@@ -367,7 +367,7 @@ class APCBToolGUI:
         self.sign_var = tk.BooleanVar(value=True)
         self.sign_chk = ttk.Checkbutton(sf, text="Sign firmware for h2offt software flash (PE Authenticode)", variable=self.sign_var)
         self.sign_chk.pack(side='left')
-        st = "✓ cryptography installed" if self.signing_available else "⚠ pip install cryptography"
+        st = "✓ cryptography installed" if self.signing_available else "⚠ pip install cryptography (venv required on SteamOS)"
         ttk.Label(sf, text=st, style='Status.TLabel').pack(side='left', padx=(12,0))
         if not self.signing_available: self.sign_var.set(False)
         br = ttk.Frame(m); br.pack(fill='x', pady=(0,8))
@@ -481,7 +481,7 @@ class APCBToolGUI:
         if do_sign and self.device_profile and not self.device_profile['supports_signing']:
             messagebox.showinfo("Signing Not Supported", f"{self.device_profile['name']} does not support firmware signing.\n\nUse SPI flash instead."); do_sign = False
         if do_sign and not self.signing_available:
-            messagebox.showwarning("Signing Unavailable", "Install: pip install cryptography\n\nContinuing unsigned."); do_sign = False
+            messagebox.showwarning("Signing Unavailable", "Install: pip install cryptography\n\nOn SteamOS, use a virtual environment:\npython -m venv --system-site-packages ~/sd-apcb-venv\nsource ~/sd-apcb-venv/bin/activate\npip install cryptography\n\nContinuing unsigned."); do_sign = False
         if do_sign and self.loaded_data[:2] != b'MZ':
             messagebox.showinfo("Signing Skipped", "Raw SPI dump — signing not applicable."); do_sign = False
         sp = Path(self.loaded_file); dn = f"{sp.stem}{'_64GB' if target==64 else '_32GB' if target==32 else '_stock'}{sp.suffix}"

--- a/sd_apcb_tool.py
+++ b/sd_apcb_tool.py
@@ -982,6 +982,11 @@ def modify_bios(input_path: str, output_path: str, target_gb: int,
         if not _check_signing_available():
             print(f"\n  ERROR: Signing requires the 'cryptography' Python package.")
             print(f"  Install it with: pip install cryptography")
+            print(f"\n  On SteamOS, use a virtual environment:")
+            print(f"    python -m venv --system-site-packages ~/sd-apcb-venv")
+            print(f"    source ~/sd-apcb-venv/bin/activate")
+            print(f"    pip install cryptography")
+            print(f"    python sd_apcb_tool.py modify ...")
             sys.exit(1)
         
         # Check if this is actually a PE file


### PR DESCRIPTION
## Summary

- Add SteamOS virtual environment setup section to README with step-by-step instructions
- Update CLI error message to include SteamOS venv commands when cryptography is missing
- Update GUI warning label and messagebox with SteamOS-specific guidance

Addresses user feedback about cryptography not being found when installed in a venv on SteamOS.

## Test plan

- [x] CLI: verified improved error message format
- [x] GUI: verified updated warning label and messagebox text
- [x] README: SteamOS setup section with correct venv commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)