### PR TITLE
Add GUI option to SteamOS venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ pip install cryptography
 
 # 5. Run the tool (while venv is active)
 python sd_apcb_tool.py modify <input> <output> --target 32 --sign
+
+# or
+python sd_apcb_gui.py
 ```
 
-You must activate the venv (`source ~/sd-apcb-venv/bin/activate`) each time before running the tool with `--sign`.
+You must activate the venv (`source ~/sd-apcb-venv/bin/activate`) each time before running the tool.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Add `python sd_apcb_gui.py` as an alternative in the SteamOS venv setup instructions
- Change "before running the tool with --sign" to "before running the tool" (venv needed for GUI too)

Small follow-up to PR #5 — the amended commit landed after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)